### PR TITLE
Add getStateChangedSignal

### DIFF
--- a/docs/replicatingdata.md
+++ b/docs/replicatingdata.md
@@ -43,6 +43,17 @@ ExampleReplicator.StateChanged:Connect(function(state, value)
 end)
 ```
 
+However, this can get a bit messy if you have multiple states in the same replicator you want to listen to (which you usually do), so here you can use the `getStateChangedSignal` method to get a signal for a specific state.
+
+```lua
+local ExampleStateSignal = ExampleReplicator:getStateChangedSignal("ExampleState")
+ExampleStateSignal:Connect(function(value)
+	print(value)
+end)
+```
+
+This will only fire when the `ExampleState` state is changed, and will provide the new value as an argument.
+
 ## Changing States
 
 To change a state in the replicator, you can use the `changeStates` method. This method will take a table of states and their new values, and will replicate them to the client.

--- a/lib/Replicator.luau
+++ b/lib/Replicator.luau
@@ -32,6 +32,7 @@ type ReplicatorImpl = {
 	_recieveUpdate: (self: Replicator, data: { syncData: { Remove: { string }?, Modify: { { Index: string, NewValue: any } }? }?, updateData: { [string]: any } }) -> (),
 	get: (self: Replicator, index: string?) -> { [string]: any } | any,
 	getForPlayer: (self: Replicator, player: Player, index: string?) -> { [string]: any } | any,
+	getStateChangedSignal: (self: Replicator, state: string) -> Signal.Signal<any>,
 	Destroy: (self: Replicator) -> ()
 }
 
@@ -128,6 +129,12 @@ function Replicator.new<T>(identifier: string | Instance, data: T?)
 	self._userStateCopies = {}
 	
 	-- // Signals
+	--[=[
+		@prop StateChanged Signal<string, any>
+		@within Replicator
+
+		A signal that fires when a state has changed
+	]=]
 	self.StateChanged = Signal.new()
 	
 	if self._context == "Server" then
@@ -528,6 +535,24 @@ function Replicator:getForPlayer(player: Player, index: string?): { [string]: an
 	end
 
 	return data
+end
+
+--[=[
+	Returns a signal that fires when a specific state has changed
+
+	@param state string -- The state to listen for changes
+	@return Signal<any>
+]=]
+function Replicator:getStateChangedSignal(state: string): Signal.Signal<any>
+	local signal = Signal.new()
+
+	self.StateChanged:Connect(function(_state, value)
+		if _state == state then
+			signal:Fire(value)
+		end
+	end)
+
+	return signal
 end
 
 --[=[

--- a/lib/types.luau
+++ b/lib/types.luau
@@ -4,6 +4,7 @@ export type Replicator<T> = {
 	get: (self: Replicator<T>, index: string?) -> T,
 	getForPlayer: (self: Replicator<T>, player: Player, index: string?) -> T,
 	syncPlayer: (self: Replicator<T>, player: Player) -> (),
+	getStateChangedSignal: (self: Replicator<T>, state: string) -> Signal.Signal<any>,
 	Destroy: (self: Replicator<T>) -> (),
 
 	StateChanged: Signal.Signal<string, any>

--- a/src/client/client.client.luau
+++ b/src/client/client.client.luau
@@ -9,4 +9,8 @@ GameStateReplicator.StateChanged:Connect(function(state, value)
 	print(GameStateReplicator:get())
 end)
 
+GameStateReplicator:getStateChangedSignal("status"):Connect(function(value)
+	print("Status changed", value)
+end)
+
 print(GameStateReplicator:get())


### PR DESCRIPTION
Adds a new method called `getStateChangedSignal` which takes in a state and returns a new signal that only fire when that signal is changed specifically