### PR TITLE
Add getMutable

### DIFF
--- a/lib/NetworkManager.luau
+++ b/lib/NetworkManager.luau
@@ -140,7 +140,7 @@ function NetworkManager:listen(tag: string, callback: (...any?) -> nil)
 
 		local decodedData = self._useBuffer and msgpack.decode(msgpack.utf8Decode(data)) or data
 
-		print(`Handling listener for {tag}:`, args)
+		print(`Handling listener for {tag}:`, decodedData)
 
 		if self._context == "OnServerEvent" then
 			callback(player, decodedData)

--- a/lib/Replicator.luau
+++ b/lib/Replicator.luau
@@ -525,15 +525,75 @@ function Replicator:get(index: string?): { [string]: any } | any
 	return data
 end
 
+--[=[
+	Returns a mutable version of the current state stored in the replicator, when a state is changed in the
+	mutable data, it will automatically replicate the change to the client
+
+	:::caution
+	Do not use `table.clear` on a table in the mutable data, it will not replicate the change to the clients
+	:::
+
+	@param players { Player } | Player? -- If provided, the mutable data will only be able to change states for the given players
+	@return { [string]: any } -- A mutable version of the current state stored in the replicator
+]=]
 function Replicator:getMutable(players: ({ Player } | Player)?): { [string]: any }
 	local dataStructure = self._localDataCopy
-	local data = {}
 
 	-- Manually clone the table to remove the metatable
-	for state, value in next, dataStructure do
-		data[state] = value
+	local function clone(tbl, parents: { any }?)
+		local data = {}
+
+		for state, value in next, tbl do
+			if type(value) == "table" then
+				print(state)
+				local newParents = parents or {}
+
+				table.insert(newParents, { tbl, state })
+
+				local cloned = clone(value, newParents)
+				local mutable = {}
+
+				setmetatable(mutable, {
+					__index = function(_, key)
+						return cloned[key]
+					end,
+					__newindex = function(_, key, newValue)
+						print("Setting", key, newValue)
+
+						value[key] = newValue
+
+						for _, parent in next, newParents do
+							local parentTbl = parent[1]
+							local parentState = parent[2]
+
+							if parentTbl[parentState] == cloned then
+								parentTbl[parentState] = cloned
+							end
+						end
+
+						local topLevelState = parents and parents[1][2] or state
+						local topLevelValue = (parents and parents[2]) and parents[2][1] or value
+
+						print("Setting state", topLevelState, topLevelValue, value)
+
+						self:changeStates({
+							[topLevelState] = topLevelValue,
+						}, players)
+					end,
+				})
+
+				data[state] = mutable
+
+				continue
+			end
+
+			data[state] = value
+		end
+
+		return data
 	end
 
+	local data = clone(dataStructure :: any)
 	local mutable = {}
 
 	setmetatable(mutable, {
@@ -544,6 +604,9 @@ function Replicator:getMutable(players: ({ Player } | Player)?): { [string]: any
 			self:changeStates({
 				[key] = value,
 			}, players)
+		end,
+		__tostring = function()
+			return "MutableReplicatorData(" .. tostring(self.identifier) .. ")"
 		end,
 	})
 

--- a/lib/Replicator.luau
+++ b/lib/Replicator.luau
@@ -44,6 +44,7 @@ type ReplicatorImpl = {
 		}
 	) -> (),
 	get: (self: Replicator, index: string?) -> { [string]: any } | any,
+	getMutable: (self: Replicator, players: ({ Player } | Player)?) -> { [string]: any },
 	getForPlayer: (self: Replicator, player: Player, index: string?) -> { [string]: any } | any,
 	getStateChangedSignal: (self: Replicator, state: string) -> Signal.Signal<any>,
 	Destroy: (self: Replicator) -> (),
@@ -246,7 +247,7 @@ function Replicator:syncPlayer(player: Player)
 		if not rawget(self._localDataCopy :: any, state) then
 			table.insert(remove, state)
 		elseif self._localDataCopy[state] ~= value then
-			-- FIXME: If a value is modified in the same frame before a sync, it will be put in the sync table even though it has not replication
+			-- FIXME: If a value is modified in the same frame before a sync, it will be put in the sync table even though it has not replicated
 			--        this isn't a huge issue but it leads to wasted data being sent to the client as the original value will be dropped during replication
 			--        meaning that replicating the value as part of a sync is now useless
 			table.insert(modify, {
@@ -522,6 +523,32 @@ function Replicator:get(index: string?): { [string]: any } | any
 	end
 
 	return data
+end
+
+function Replicator:getMutable(players: ({ Player } | Player)?): { [string]: any }
+	local dataStructure = self._localDataCopy
+	local data = {}
+
+	-- Manually clone the table to remove the metatable
+	for state, value in next, dataStructure do
+		data[state] = value
+	end
+
+	local mutable = {}
+
+	setmetatable(mutable, {
+		__index = function(_, key)
+			return data[key]
+		end,
+		__newindex = function(_, key, value)
+			self:changeStates({
+				[key] = value,
+			}, players)
+		end,
+	})
+
+	-- I have no idea how to properly type this :(
+	return (mutable :: any) :: { [string]: any }
 end
 
 --[=[

--- a/lib/types.luau
+++ b/lib/types.luau
@@ -2,6 +2,7 @@ local Signal = require(script.Parent.Signal)
 export type Replicator<T> = {
 	changeStates: (self: Replicator<T>, changedStates: T, players: ({ Player } | Player)?) -> (),
 	get: (self: Replicator<T>, index: string?) -> T,
+	getMutable: (self: Replicator<T>, players: ({ Player } | Player)?) -> T,
 	getForPlayer: (self: Replicator<T>, player: Player, index: string?) -> T,
 	syncPlayer: (self: Replicator<T>, player: Player) -> (),
 	getStateChangedSignal: (self: Replicator<T>, state: string) -> Signal.Signal<any>,

--- a/src/server/StringReplication.server.luau
+++ b/src/server/StringReplication.server.luau
@@ -11,6 +11,13 @@ local GameStateReplicator = Replicator.new(
 	{
 		status = "none" :: string?,
 		status2 = "none" :: string?,
+		testTable = {
+			nestedTable = {
+				nestedTable2 = {
+					Hello = "World",
+				}
+			}
+		},
 	}
 )
 
@@ -21,6 +28,7 @@ task.wait(5)
 -- })
 
 GameStateReplicator:getMutable().status = "SHARED!!!!"
+GameStateReplicator:getMutable().testTable.nestedTable.nestedTable2.Hello = "World2"
 
 GameStateReplicator.StateChanged:Connect(function(index, value)
 	print("State changed", index, value)

--- a/src/server/StringReplication.server.luau
+++ b/src/server/StringReplication.server.luau
@@ -9,26 +9,32 @@ local Replicator = require(ReplicatedStorage.Shared.SimplyReplicate)
 local GameStateReplicator = Replicator.new(
 	"GameState",
 	{
-		status = "none",
-		status2 = "none",
-	} :: any
+		status = "none" :: string?,
+		status2 = "none" :: string?,
+	}
 )
 
 task.wait(5)
 
-GameStateReplicator:changeStates({
-	status = "SHARED!!!!",
-})
+-- GameStateReplicator:changeStates({
+-- 	status = "SHARED!!!!",
+-- })
+
+GameStateReplicator:getMutable().status = "SHARED!!!!"
 
 GameStateReplicator.StateChanged:Connect(function(index, value)
 	print("State changed", index, value)
 end)
 
 for _, v in Players:GetPlayers() do
-	GameStateReplicator:changeStates({
-		status = "Hello world, this is overriden for " .. v.Name,
-		status2 = v.Name,
-	}, v)
+	-- GameStateReplicator:changeStates({
+	-- 	status = "Hello world, this is overriden for " .. v.Name,
+	-- 	status2 = v.Name,
+	-- }, v)
+
+	local mutable = GameStateReplicator:getMutable(v)
+	mutable.status = "Hello world, this is overriden for " .. v.Name
+	mutable.status2 = v.Name
 end
 
 for _, v in Players:GetPlayers() do


### PR DESCRIPTION
Adds a `getMutable` function which allows you to make inline changes directly to the table, and automatically replicate them, even with support for nested tables!

```luau
local mutable = Replicator:getMutable()
mutable.hello = "hi"
mutable.table.hello = "hi"
```

This is equivalent to

```luau
Replicator:changeStates({
    hello = "hi",
    table = {
        hello = "hi"
    } -- You would have to specify everything in the table before, not with mutable however
})
```